### PR TITLE
Remove screenshot flag from design search

### DIFF
--- a/magi/src/magi_agents/web_agents/design_agent.ts
+++ b/magi/src/magi_agents/web_agents/design_agent.ts
@@ -11,6 +11,7 @@
 import { Agent } from '../../utils/agent.js';
 import { getCommonTools } from '../../utils/index.js';
 import { getImageGenerationTools } from '../../utils/image_generation.js';
+import { createDesignSearchTool } from '../../utils/design_search.js';
 import { MAGI_CONTEXT } from '../constants.js';
 import { createReasoningAgent } from '../common_agents/reasoning_agent.js';
 
@@ -78,6 +79,7 @@ Save assets in a structured format:
 The frontend engineer will use your designs as reference for implementation, so clarity is critical.
 `,
         tools: [
+            createDesignSearchTool(),
             ...getImageGenerationTools(),
             ...getCommonTools()
         ],


### PR DESCRIPTION
## Summary
- always capture screenshots in `design_search`
- remove `takeScreenshots` parameter from `createDesignSearchTool`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*