### PR TITLE
Add ResearchOperatorAgent

### DIFF
--- a/magi/src/magi_agents/common_agents/verifier_agent.ts
+++ b/magi/src/magi_agents/common_agents/verifier_agent.ts
@@ -1,0 +1,26 @@
+/**
+ * Verifier agent for checking research citations.
+ */
+
+import { Agent } from '../../utils/agent.js';
+import { getCommonTools } from '../../utils/index.js';
+import { getSearchTools } from '../../utils/search_utils.js';
+import { MAGI_CONTEXT, COMMON_WARNINGS } from '../constants.js';
+
+/**
+ * Create the verifier agent used in research workflows.
+ */
+export function createVerifierAgent(): Agent {
+    return new Agent({
+        name: 'VerifierAgent',
+        description: 'Validates research citations against gathered evidence.',
+        instructions: `${MAGI_CONTEXT}
+---
+You are **VerifierAgent**.
+Your job is to ensure that every claim in RESEARCH_REPORT.md is backed by evidence in research_notes.json.
+Cross-check citations, flag mismatches, and suggest corrections.
+${COMMON_WARNINGS}`,
+        tools: [...getSearchTools(), ...getCommonTools()],
+        modelClass: 'reasoning_mini',
+    });
+}

--- a/magi/src/magi_agents/index.ts
+++ b/magi/src/magi_agents/index.ts
@@ -16,6 +16,7 @@ import { ModelClassID } from '../model_providers/model_data.js';
 import { createOperatorAgent } from './operator_agent.js';
 import { createProjectOperatorAgent } from './project_agents/operator_agent.js';
 import { createWebOperatorAgent } from './web_agents/operator_agent.js';
+import { createResearchOperatorAgent } from './research_agents/operator_agent.js';
 
 // Export all constants from the constants module
 export * from './constants.js';
@@ -68,6 +69,9 @@ export async function createAgent(
                 break;
             case 'web_code':
                 agent = createWebOperatorAgent();
+                break;
+            case 'research':
+                agent = await createResearchOperatorAgent();
                 break;
             default:
                 agent = createOperatorAgent();
@@ -147,4 +151,5 @@ export {
     createShellAgent,
     createImageAgent,
     createProjectOperatorAgent,
+    createResearchOperatorAgent,
 };

--- a/magi/src/magi_agents/research_agents/operator_agent.ts
+++ b/magi/src/magi_agents/research_agents/operator_agent.ts
@@ -1,0 +1,68 @@
+import { Agent } from '../../utils/agent.js';
+import { getCommonTools } from '../../utils/index.js';
+import { createReasoningAgent } from '../common_agents/reasoning_agent.js';
+import { createSearchAgent } from '../common_agents/search_agent.js';
+import { createVerifierAgent } from '../common_agents/verifier_agent.js';
+import { createOperatorAgent, startTime } from '../operator_agent.js';
+import { MAGI_CONTEXT } from '../constants.js';
+import { getSearchTools } from '../../utils/search_utils.js';
+import { get_output_dir } from '../../utils/file_utils.js';
+import { ResponseInput } from '../../types/shared-types.js';
+import { runningToolTracker } from '../../utils/running_tool_tracker.js';
+import { dateFormat, readableTime } from '../../utils/date_tools.js';
+import { getThoughtDelay } from '../../utils/thought_utils.js';
+
+/**
+ * ResearchOperatorAgent v2 – Incorporating multi-engine parallel search, explicit planning, and a verify-after-write pass.
+ */
+
+export async function createResearchOperatorAgent(): Promise<Agent> {
+    const outputDir = get_output_dir('research');
+    const depth = process.env.RESEARCH_DEPTH ?? 'standard';
+
+    /* --------------------------- Agent Instructions --------------------------- */
+    const instructions = `${MAGI_CONTEXT}
+
+---
+You are **ResearchOperatorAgent** (v2).
+
+**Mission:** Deliver a *fully cited*, high-quality research report while following a rigorous, auditable workflow.
+
+## Workflow Overview
+0. **Clarify Scope** – Detect ambiguities; if any, ask the user concise follow-up questions *once* before continuing.
+1. **Plan & Decompose**
+   • Break the prompt into granular sub-questions.
+   • For each sub-question, choose preferred search engines (multi-engine strategy) and priority level.
+   • Persist this plan to \`research_plan.json\`.
+2. **Search & Gather**
+   • Spawn SearchAgents in parallel using the planned engines.
+   • Merge findings into \`research_notes.json#evidence\`.
+3. **Synthesize**
+   • Use a ReasoningAgent to compose \`RESEARCH_REPORT.md\` with citations.
+4. **Verify**
+   • Run a VerifierAgent to check citations against the evidence.
+   • Fix issues or trigger additional searches until verification passes.
+
+Depth mode: ${depth}. Save all output files in ${outputDir}.`;
+
+    return createOperatorAgent({
+        name: 'ResearchOperatorAgent',
+        description: 'Coordinates multi-engine research and produces verified reports.',
+        instructions,
+        tools: [...getSearchTools(), ...getCommonTools()],
+        workers: [createSearchAgent, createReasoningAgent, createVerifierAgent],
+        onRequest: async (
+            agent: Agent,
+            messages: ResponseInput,
+        ): Promise<[Agent, ResponseInput]> => {
+            messages.push({
+                type: 'message',
+                role: 'developer',
+                content: `=== Operator Status ===\n\nCurrent Time: ${dateFormat()}\nYour Running Time: ${readableTime(
+                    new Date().getTime() - startTime.getTime()
+                )}\nYour Thought Delay: ${getThoughtDelay()} seconds\n\nActive Tools:\n${runningToolTracker.listActive()}\nOutput Directory: ${outputDir}\nDepth Mode: ${depth}`,
+            });
+            return [agent, messages];
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- add ResearchOperatorAgent and VerifierAgent
- export ResearchOperatorAgent in agent registry
- support `research` tool in agent creation
- refine ResearchOperatorAgent status output

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-sh')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*