### PR TITLE
Update MAGI_CONTEXT and overseer instructions

### DIFF
--- a/magi/src/magi_agents/constants.ts
+++ b/magi/src/magi_agents/constants.ts
@@ -171,4 +171,11 @@ Key Communication Paths
 4. Overseer <-> Operator (WebSockets)
 5. Operator <-> Agents (Same container via tool calls)
 6. Browser Agent <-> Browser (CDP)
-7. Overseer/Agents <-> External Services (HTTP/API)`;
+7. Overseer/Agents <-> External Services (HTTP/API)
+
+III. Project Workflow
+- Projects are created with `create_project(project_id, simple_description, detailed_description, project_type)`.
+- The controller copies starting code from `/templates/<project_type>` into a new git repository under `/external/host/<project_id>`. If the specific template does not exist, the `web-app` template is used.
+- Placeholder text in `README.md`, `CLAUDE.md`, `AGENTS.md`, and `project_map.json` is replaced with the provided descriptions.
+- Once the repository is ready a **ProjectOperatorAgent** analyzes the project, generates the codebase map and context files, and updates the database.
+`;

--- a/magi/src/magi_agents/overseer_agent.ts
+++ b/magi/src/magi_agents/overseer_agent.ts
@@ -299,6 +299,10 @@ Your older thoughts are summarized so that they can fit in your context window.
 
 **Primary Tool: Start Task**
 start_task() - Does things! Plans, executes then validates. A team managed by a operator agent which can write code, interact with web pages, think on topics, and run shell commands. The task can be used to perform any task you can think of. You can create a task to handle anything you want to perform. Use this to find information and interact with the world. Tasks can be given access to active projects to work on existing files. ${getExternalProjectIds().includes('magi-system') ? ' You can give them access to "magi-system" to review and modify your own code.' : ''} Once the agents have completed their task, they will return the results to you. If they were working on projects, a branch named magi-{taskId} will be created with the changes.
+Only the Overseer can create operator agents to manage tasks. Choose the operator type best suited for the task:
+- **OperatorAgent** – general purpose planner that breaks tasks into subtasks for specialized agents.
+- **WebOperatorAgent** – focused on full website delivery (research → design → code → test).
+- **ProjectOperatorAgent** – automatically spawned after project creation to analyze the template, generate documentation and update the database.
 
 Your tasks & agents operate in a shared browsing session with ${person}. This allows you to interact with websites together. You can access accounts ${person} is already logged into and perform actions for them.
 


### PR DESCRIPTION
## Summary
- explain how projects pull templates and are analyzed at creation
- move operator type description to overseer agent

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run test:tools` *(fails: docker: command not found)*