### PR TITLE
Fix abort signal injection for waiting tools

### DIFF
--- a/magi/src/utils/tool_call.ts
+++ b/magi/src/utils/tool_call.ts
@@ -835,6 +835,12 @@ export function createToolFunction(
         injectAgentId = true;
     }
 
+    // Similarly check for abort_signal if paramMap omitted it but the function
+    // signature includes it so we can inject the abort signal automatically
+    if (!injectAbortSignal && /\(.*abort_signal\b/.test(funcStr)) {
+        injectAbortSignal = true;
+    }
+
     // Create and return tool definition
     return {
         function: func,


### PR DESCRIPTION
## Summary
- ensure tools receive abort_signal when paramMap omits it

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run test:tools` *(fails: docker: command not found)*