### PR TITLE
Implement verifier agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ docker-compose.yml
 - **Tool Integration**: Agents can use tools like web search, code execution, and browser automation
 - **Browser Integration**: Chrome extension allows direct interaction with the web browser
 - **Cost Tracking**: Monitors and reports on API usage costs
+- **Verifier Agents**: Optional verifier agents can call any tools; failures trigger automatic retries (default 2)
 
 ## Command Line Utilities
 

--- a/common/shared-types.ts
+++ b/common/shared-types.ts
@@ -41,6 +41,7 @@ export interface AgentInterface {
     modelClass?: string;
     modelSettings?: ModelSettings;
     maxToolCalls?: number;
+    verifier?: AgentInterface; // Optional verifier agent
     onToolCall?: (toolCall: ToolCall) => void;
     onToolResult?: (toolCall: ToolCall, result: string) => void;
     tryDirectExecution?: (messages: ResponseInput) => Promise<ResponseInput | null>; // Added from AgentDefinition
@@ -139,6 +140,11 @@ export type ToolParameterMap = {
         | ToolParameter;
 };
 
+export interface VerifierResult {
+    status: 'pass' | 'fail';
+    reason?: string;
+}
+
 /**
  * Definition of an agent with model and tool settings
  */
@@ -154,6 +160,8 @@ export interface AgentDefinition {
     modelSettings?: ModelSettings;
     maxToolCalls?: number;
     maxToolCallRoundsPerTurn?: number; // Maximum number of tool call rounds per turn
+    verifier?: AgentDefinition;
+    maxVerificationAttempts?: number;
     jsonSchema?: object; // JSON schema definition for structured output
     historyThread?: ResponseInput | undefined;
     cwd?: string; // Working directory for model providers that need a real shell context


### PR DESCRIPTION
## Summary
- add VerifierResult type and verifier fields to agent types
- instantiate verifier agent and add config in Agent constructor
- implement Runner.verifyRun helper and verification logic
- simplify runAgentTool wrapper
- document verifier agent feature in README
- fix verifier interface type mismatch

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run test:tools` *(fails: docker not found)*