### PR TITLE
Fix Sass warnings in build

### DIFF
--- a/controller/src/client/css/styles.scss
+++ b/controller/src/client/css/styles.scss
@@ -1,14 +1,11 @@
-/* Override Bootstrap variables */
-$primary: #00a2ff;
-$bg-primary: #00a2ff;
-$code-color: #000000;
-
 /* Import Bootstrap and Bootstrap Icons */
-@import '~bootstrap/scss/bootstrap';
+@import 'bootstrap/dist/css/bootstrap.css';
 @import 'bootstrap-icons/font/bootstrap-icons.css';
 
 /* Default theme styling */
 :root {
+    --bs-primary: #00a2ff;
+    --bs-code-color: #000000;
     /* Core colors */
     --bg-primary: #fff;
     --bg-secondary: #f8f9fb;


### PR DESCRIPTION
## Summary
- import Bootstrap CSS instead of SCSS
- set Bootstrap CSS vars for custom colors

## Testing
- `npm run build:ci`
- `npm run lint:fix` *(fails: 29 errors)*
