### PR TITLE
Add local custom tool syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ yarn-error.log
 *.js.map
 *.jsx
 #*.css
+# Local custom tools (not versioned)
+.custom_tools/
 
 # Allow specific JS files
 !host/setup.js

--- a/controller/docker/Dockerfile
+++ b/controller/docker/Dockerfile
@@ -43,8 +43,8 @@ RUN groupadd -g 998 docker || true && \
     usermod -aG docker ${USER_NAME}
 
 # Create volume mount points
-RUN mkdir -p /magi_output /claude_shared /external/host && \
-	chown -R ${USER_NAME}:${GROUP_NAME} /magi_output /claude_shared /external/host
+RUN mkdir -p /magi_output /claude_shared /external/host /custom_tools && \
+        chown -R ${USER_NAME}:${GROUP_NAME} /magi_output /claude_shared /external/host /custom_tools
 
 # Expose the ports
 EXPOSE 3010

--- a/controller/src/server/managers/container_manager.ts
+++ b/controller/src/server/managers/container_manager.ts
@@ -184,7 +184,9 @@ async function prepareGitRepository(
         // 2. Create the working copy with the mirror as its origin
         console.log('Cloning working copy from mirror', mirrorPath, outputPath);
         await execPromise(`git clone "${mirrorPath}" "${outputPath}"`);
-        await execPromise(`git -C "${outputPath}" remote set-url origin "${mirrorPath}"`);
+        await execPromise(
+            `git -C "${outputPath}" remote set-url origin "${mirrorPath}"`
+        );
 
         // Host path will be deterministically derived from projectId
 
@@ -207,9 +209,7 @@ async function prepareGitRepository(
         }
 
         // Set git config for commits
-        await execPromise(
-            `git -C "${outputPath}" config user.name "magi"`
-        );
+        await execPromise(`git -C "${outputPath}" config user.name "magi"`);
         await execPromise(
             `git -C "${outputPath}" config user.email "magi+${processId}@withmagi.com"`
         );
@@ -260,8 +260,11 @@ async function copyTemplateToProject(
         console.log('Replacing placeholders in template files');
 
         // Get description values (provide defaults if not available)
-        const simpleDescription = project?.simple_description || 'A new project';
-        const detailedDescription = project?.detailed_description || 'A detailed description of the project.';
+        const simpleDescription =
+            project?.simple_description || 'A new project';
+        const detailedDescription =
+            project?.detailed_description ||
+            'A detailed description of the project.';
 
         // Find all .md files in the project root
         const files = fs.readdirSync(projectPath);
@@ -280,14 +283,23 @@ async function copyTemplateToProject(
                 let content = fs.readFileSync(filePath, 'utf8');
 
                 // Replace placeholders
-                content = content.replace(/\[simple_description\]/g, simpleDescription);
-                content = content.replace(/\[detailed_description\]/g, detailedDescription);
+                content = content.replace(
+                    /\[simple_description\]/g,
+                    simpleDescription
+                );
+                content = content.replace(
+                    /\[detailed_description\]/g,
+                    detailedDescription
+                );
 
                 // Write updated content back to file
                 fs.writeFileSync(filePath, content, 'utf8');
                 console.log(`Replaced placeholders in ${file}`);
             } catch (fileError) {
-                console.error(`Error replacing placeholders in ${file}:`, fileError);
+                console.error(
+                    `Error replacing placeholders in ${file}:`,
+                    fileError
+                );
                 // Continue with other files even if one fails
             }
         }
@@ -306,9 +318,7 @@ async function copyTemplateToProject(
  * @param processManager Optional ProcessManager instance to create an agent process
  * @returns The project name if successful, null if it fails
  */
-export async function createNewProject(
-    projectId: string,
-): Promise<void> {
+export async function createNewProject(projectId: string): Promise<void> {
     const project = await getProject(projectId);
     if (!project) {
         throw new Error(`Project ${projectId} not found in database`);
@@ -439,18 +449,12 @@ export async function runDockerContainer(
 
             for (const projectId of gitProjects) {
                 // If this run _is_ the core process, skip waiting and exclude itself
-                if (
-                    coreProcessId &&
-                    coreProcessId === processId
-                ) {
+                if (coreProcessId && coreProcessId === processId) {
                     readyProjects.push(projectId);
                     continue;
                 }
 
-                if (
-                    tool &&
-                    tool === 'project_update'
-                ) {
+                if (tool && tool === 'project_update') {
                     readyProjects.push(projectId);
                     continue;
                 }
@@ -526,6 +530,7 @@ export async function runDockerContainer(
       --env-file ${path.resolve(projectRoot, '../.env')} \
       -v claude_credentials:/claude_shared:rw \
       -v magi_output:/magi_output:rw \
+      -v /external/host/magi-system/.custom_tools:/custom_tools:rw \
       -v /etc/timezone:/etc/timezone:ro \
       -v /etc/localtime:/etc/localtime:ro \
       --network magi-system_magi-network \

--- a/controller/src/server/server.ts
+++ b/controller/src/server/server.ts
@@ -12,6 +12,7 @@ import express from 'express';
 import { ServerManager } from './managers/server_manager';
 import { initColorManager } from './managers/color_manager';
 import { ensureMigrations } from './utils/db_migrations';
+import { syncLocalCustomTools } from './utils/custom_tool_sync';
 import prEventsRoutes from './routes/pr_events';
 
 /**
@@ -19,12 +20,14 @@ import prEventsRoutes from './routes/pr_events';
  */
 async function main(): Promise<void> {
     // Add CPU usage debug logging
-    const cpuMonitorInterval = setInterval(() => {
+    setInterval(() => {
         const usage = process.cpuUsage();
         const totalUsage = usage.user + usage.system;
-        console.log(`[DEBUG] CPU usage - user: ${usage.user}, system: ${usage.system}, total: ${totalUsage}`);
+        console.log(
+            `[DEBUG] CPU usage - user: ${usage.user}, system: ${usage.system}, total: ${totalUsage}`
+        );
     }, 10000);
-    
+
     // Check OpenAI API key
     if (!process.env.OPENAI_API_KEY) {
         console.warn('\n⚠ OPENAI_API_KEY not set. Voice disabled.\n');
@@ -32,6 +35,9 @@ async function main(): Promise<void> {
 
     // Run database migrations before starting the server
     await ensureMigrations();
+
+    // Sync local custom tools
+    await syncLocalCustomTools();
 
     // Initialize color manager
     initColorManager();

--- a/controller/src/server/utils/custom_tool_sync.ts
+++ b/controller/src/server/utils/custom_tool_sync.ts
@@ -1,0 +1,103 @@
+import path from 'path';
+import { getDB } from './db.js';
+import fs from 'fs/promises';
+
+interface CustomTool {
+    name: string;
+    description: string;
+    parameters_json: string;
+    version?: number;
+}
+
+const TOOLS_DIR = path.resolve('.custom_tools');
+
+async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function readLocalTools(): Promise<CustomTool[]> {
+    const tools: CustomTool[] = [];
+    try {
+        await fs.mkdir(TOOLS_DIR, { recursive: true });
+        const files = await fs.readdir(TOOLS_DIR);
+        for (const file of files) {
+            if (!file.endsWith('.json')) continue;
+            const name = file.replace(/\.json$/, '');
+            const metaRaw = await fs.readFile(
+                path.join(TOOLS_DIR, file),
+                'utf8'
+            );
+            let meta: any = {};
+            try {
+                meta = JSON.parse(metaRaw);
+            } catch {
+                continue;
+            }
+            const codePathTs = path.join(TOOLS_DIR, `${name}.ts`);
+            const codePathJs = path.join(TOOLS_DIR, `${name}.js`);
+            if (
+                !(await fileExists(codePathTs)) &&
+                !(await fileExists(codePathJs))
+            ) {
+                continue;
+            }
+            tools.push({
+                name,
+                description: meta.description || '',
+                parameters_json: meta.parameters_json || '{}',
+                version: meta.version || 1,
+            });
+        }
+    } catch (err) {
+        console.error('Error reading local tools:', err);
+    }
+    return tools;
+}
+
+export async function syncLocalCustomTools(): Promise<void> {
+    const client = await getDB();
+    try {
+        const { rows } = await client.query(
+            'SELECT name FROM custom_tools WHERE is_latest = true'
+        );
+        const existing = new Set<string>(rows.map(r => r.name));
+
+        const localTools = await readLocalTools();
+        const localNames = new Set(localTools.map(t => t.name));
+
+        for (const tool of localTools) {
+            await client.query(
+                `INSERT INTO custom_tools (name, description, parameters_json, version, is_latest)
+                 VALUES ($1,$2,$3,$4,true)
+                 ON CONFLICT (name)
+                 DO UPDATE SET description=EXCLUDED.description,
+                               parameters_json=EXCLUDED.parameters_json,
+                               version=EXCLUDED.version,
+                               is_latest=true`,
+                [
+                    tool.name,
+                    tool.description,
+                    tool.parameters_json,
+                    tool.version || 1,
+                ]
+            );
+        }
+
+        for (const name of existing) {
+            if (!localNames.has(name)) {
+                await client.query('DELETE FROM custom_tools WHERE name = $1', [
+                    name,
+                ]);
+            }
+        }
+    } catch (err) {
+        console.error('Error syncing local custom tools:', err);
+    } finally {
+        client.release();
+    }
+}

--- a/db/migrations/2025052000001_remove_custom_tool_implementation.sql
+++ b/db/migrations/2025052000001_remove_custom_tool_implementation.sql
@@ -1,0 +1,7 @@
+-- Remove implementation column from custom_tools
+BEGIN;
+
+ALTER TABLE custom_tools
+    DROP COLUMN IF EXISTS implementation;
+
+COMMIT;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         volumes:
             - claude_credentials:/claude_shared:rw # For Claude auth
             - magi_output:/magi_output:rw # For output storage
+            - ./.custom_tools:/custom_tools:rw # Local custom tools
             - ../:/external/host:rw # Mount parent directory for repo management
             - ./.env:/.env:ro # Mount .env file in parent directory (where server expects it)
             - /var/run/docker.sock:/var/run/docker.sock # Allow Docker-in-Docker
@@ -60,6 +61,7 @@ services:
             - ./magi/src:/app/src:rw # Mount source code for development hot reloading
             - claude_credentials:/claude_shared:rw
             - magi_output:/magi_output:rw
+            - ./.custom_tools:/custom_tools:rw
         env_file:
             - ./.env
         environment:

--- a/magi/docker/Dockerfile
+++ b/magi/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN groupadd --gid ${TARGET_GID} ${GROUP_NAME} || true && \
 ########################################################################
 # ---- App directory setup --------------------------------------------
 ########################################################################
-RUN mkdir -p /app /magi_output /claude_shared && \
+RUN mkdir -p /app /magi_output /claude_shared /custom_tools && \
     chown -R ${USER_NAME}:${GROUP_NAME} /app
 
 WORKDIR /app

--- a/magi/src/utils/tool_file_utils.ts
+++ b/magi/src/utils/tool_file_utils.ts
@@ -1,0 +1,89 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { CustomTool } from './db_utils.js';
+
+export const TOOLS_DIR = path.resolve('.custom_tools');
+
+async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function saveToolFiles(tool: CustomTool): Promise<void> {
+    await fs.mkdir(TOOLS_DIR, { recursive: true });
+    const codePath = path.join(TOOLS_DIR, `${tool.name}.ts`);
+    const metaPath = path.join(TOOLS_DIR, `${tool.name}.json`);
+    await fs.writeFile(codePath, tool.implementation, 'utf8');
+    const meta = {
+        description: tool.description,
+        parameters_json: tool.parameters_json,
+        version: tool.version || 1,
+    };
+    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf8');
+}
+
+export async function readToolImplementation(
+    name: string
+): Promise<string | null> {
+    const codePathTs = path.join(TOOLS_DIR, `${name}.ts`);
+    const codePathJs = path.join(TOOLS_DIR, `${name}.js`);
+    if (await fileExists(codePathTs)) return fs.readFile(codePathTs, 'utf8');
+    if (await fileExists(codePathJs)) return fs.readFile(codePathJs, 'utf8');
+    return null;
+}
+
+export async function deleteToolFiles(name: string): Promise<void> {
+    const codePathTs = path.join(TOOLS_DIR, `${name}.ts`);
+    const codePathJs = path.join(TOOLS_DIR, `${name}.js`);
+    const metaPath = path.join(TOOLS_DIR, `${name}.json`);
+    if (await fileExists(codePathTs)) await fs.unlink(codePathTs);
+    if (await fileExists(codePathJs)) await fs.unlink(codePathJs);
+    if (await fileExists(metaPath)) await fs.unlink(metaPath);
+}
+
+export async function readLocalTools(): Promise<CustomTool[]> {
+    const tools: CustomTool[] = [];
+    try {
+        await fs.mkdir(TOOLS_DIR, { recursive: true });
+        const files = await fs.readdir(TOOLS_DIR);
+        for (const file of files) {
+            if (!file.endsWith('.json')) continue;
+            const name = file.replace(/\.json$/, '');
+            const metaRaw = await fs.readFile(
+                path.join(TOOLS_DIR, file),
+                'utf8'
+            );
+            let meta: any = {};
+            try {
+                meta = JSON.parse(metaRaw);
+            } catch {
+                continue;
+            }
+            const codePathTs = path.join(TOOLS_DIR, `${name}.ts`);
+            const codePathJs = path.join(TOOLS_DIR, `${name}.js`);
+            let implementation = '';
+            if (await fileExists(codePathTs)) {
+                implementation = await fs.readFile(codePathTs, 'utf8');
+            } else if (await fileExists(codePathJs)) {
+                implementation = await fs.readFile(codePathJs, 'utf8');
+            } else {
+                continue;
+            }
+            tools.push({
+                name,
+                description: meta.description || '',
+                parameters_json: meta.parameters_json || '{}',
+                implementation,
+                version: meta.version || 1,
+                is_latest: true,
+            });
+        }
+    } catch (err) {
+        console.error('Error reading local tools:', err);
+    }
+    return tools;
+}


### PR DESCRIPTION
## Summary
- ignore `.custom_tools/`
- save custom tool code to `.custom_tools/`
- mount `.custom_tools/` in Docker services and containers
- load local tool files on controller startup
- drop `implementation` from custom_tools table

## Testing
- `npx eslint controller/src/server/managers/container_manager.ts controller/src/server/utils/custom_tool_sync.ts magi/src/utils/db_utils.ts magi/src/utils/tool_file_utils.ts --fix`
- `npm run build:ci`
