### PR TITLE
Enable per-task project containers and web operator browser setup

### DIFF
--- a/common/shared-types.ts
+++ b/common/shared-types.ts
@@ -24,6 +24,7 @@ declare global {
             PROJECT_REPOSITORIES?: string;
             PROJECT_PARENT_PATH?: string;
             PROCESS_PROJECTS?: string;
+            PROJECT_PORTS?: string;
         }
     }
 }

--- a/controller/src/server/managers/process_manager.ts
+++ b/controller/src/server/managers/process_manager.ts
@@ -28,6 +28,7 @@ import {
     stopDockerContainer,
     monitorContainerLogs,
     getRunningMagiContainers,
+    runProjectContainers,
 } from './container_manager';
 import { CommunicationManager } from './communication_manager';
 
@@ -381,6 +382,18 @@ export class ProcessManager {
                 );
             }
 
+            // If any projects have Dockerfiles, start them and capture ports
+            let projectPorts: Record<string, string> = {};
+            if (
+                agentProcess?.projectIds &&
+                agentProcess.projectIds.length > 0
+            ) {
+                projectPorts = await runProjectContainers(
+                    processId,
+                    agentProcess.projectIds
+                );
+            }
+
             // Get project root directory for volume mounting
 
             // Step 4: Start the Docker container
@@ -390,6 +403,7 @@ export class ProcessManager {
                 tool,
                 coreProcessId: this.coreProcessId,
                 projectIds: agentProcess?.projectIds,
+                projectPorts,
             });
 
             // Handle container start failure

--- a/magi/src/utils/project_utils.ts
+++ b/magi/src/utils/project_utils.ts
@@ -32,6 +32,22 @@ export function getProcessProjectIds(): string[] {
     return projectList.filter(project => project !== '');
 }
 
+export function getProcessProjectPorts(): Record<string, string> {
+    const ports = process.env.PROJECT_PORTS || '';
+    const entries = ports
+        .split(',')
+        .map(pair => pair.trim())
+        .filter(pair => pair);
+    const map: Record<string, string> = {};
+    for (const entry of entries) {
+        const [id, port] = entry.split(':');
+        if (id && port) {
+            map[id.toLowerCase()] = port;
+        }
+    }
+    return map;
+}
+
 export async function getAllProjectIds(): Promise<string[]> {
     // Get all project IDs from the database
     const db = await getDB();


### PR DESCRIPTION
## Summary
- launch per-project docker containers when starting tasks
- expose their ports to agent containers
- ensure containers get cleaned up
- add PROJECT_PORTS env handling
- feed browser status into WebOperatorAgent
- initialize WebOperatorAgent browser using dynamic port

## Testing
- `npm run lint:fix`
- `npm run build:ci`
