### PR TITLE
Fix typographical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Think of Magi like a co-worker. She might make some mistakes, but she learns fro
 
 ## Architecture Overview
 
-Magí consists of four core components:
+Magi consists of four core components:
 
 • **Controller Service** (`controller/`)
   - Node.js (TypeScript) Express backend + Socket.IO


### PR DESCRIPTION
## Summary
- fix the spelling of MAGI in the architecture overview section

## Testing
- `npm run lint:fix`
- `npm run build:ci`
