### PR TITLE
Expose custom tools API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,19 @@ docker-compose.yml
 - **Smart Design Search**: Aggregates screenshots from multiple design sources and ranks them automatically
 - **Cost Tracking**: Monitors and reports on API usage costs
 - **Verifier Agents**: Optional verifier agents can call any tools; failures trigger automatic retries (default 2)
+- **Custom Tools API**: Exposes HTTP endpoints for listing and inspecting dynamic tools
+- **Custom Tools Viewer**: View and inspect dynamic tools directly in the web UI
 
 ## Command Line Utilities
 
 - **List Process Output**: `./scripts/list-output.sh`
 - **Clear Process Output**: `./scripts/clear-process-output.sh <process-id>`
 - **Clear All Output**: `./scripts/clear-output.sh`
+
+## API Endpoints
+
+- **GET /api/custom-tools** – List all available custom tools
+- **GET /api/custom-tools/:name** – Retrieve a specific custom tool by name
 
 ## Testing
 

--- a/controller/src/client/js/components/CustomToolsViewer.tsx
+++ b/controller/src/client/js/components/CustomToolsViewer.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+
+interface CustomTool {
+    name: string;
+    description: string;
+    parameters_json: string;
+    version: number;
+    source_task_id: string | null;
+    is_latest: boolean;
+    created_at: string;
+    implementation?: string | null;
+}
+
+const CustomToolsViewer: React.FC = () => {
+    const [tools, setTools] = useState<CustomTool[]>([]);
+    const [selectedTool, setSelectedTool] = useState<CustomTool | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetchTools();
+    }, []);
+
+    const fetchTools = async () => {
+        try {
+            const res = await fetch('/api/custom-tools');
+            if (!res.ok) {
+                throw new Error('Failed to fetch tools');
+            }
+            const data = await res.json();
+            setTools(data);
+        } catch (err) {
+            console.error('Error fetching custom tools:', err);
+            setError('Failed to fetch custom tools');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="custom-tools-viewer">
+            <h3>Custom Tools</h3>
+            {loading && <div>Loading...</div>}
+            {error && <div className="alert alert-danger">{error}</div>}
+            {!loading && !error && (
+                <div className="d-flex">
+                    <ul
+                        className="list-group flex-grow-1"
+                        style={{ maxWidth: '250px' }}
+                    >
+                        {tools.map(tool => (
+                            <li
+                                key={tool.name}
+                                className="list-group-item list-group-item-action p-2"
+                                onClick={() => setSelectedTool(tool)}
+                                style={{ cursor: 'pointer' }}
+                            >
+                                <div className="fw-bold">{tool.name}</div>
+                                <div className="small text-muted">
+                                    {tool.description}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                    {selectedTool && (
+                        <div className="ms-3 flex-grow-1 overflow-auto">
+                            <h4>{selectedTool.name}</h4>
+                            <pre style={{ whiteSpace: 'pre-wrap' }}>
+                                {selectedTool.implementation ||
+                                    'No implementation found.'}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default CustomToolsViewer;

--- a/controller/src/client/js/components/column_ui/ColumnLayout.tsx
+++ b/controller/src/client/js/components/column_ui/ColumnLayout.tsx
@@ -5,6 +5,7 @@ import ChatColumn from './ChatColumn';
 import ProcessTreeColumn from './ProcessTreeColumn';
 import OutputColumn from './OutputColumn';
 import PullRequestFailures from '../PullRequestFailures';
+import CustomToolsViewer from '../CustomToolsViewer';
 
 interface ColumnLayoutProps {}
 
@@ -12,9 +13,9 @@ const ColumnLayout: React.FC<ColumnLayoutProps> = () => {
     const { processes, coreProcessId, costData, isPaused, togglePauseState } =
         useSocket();
     const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
-    const [middleTab, setMiddleTab] = useState<'tasks' | 'code' | 'complete'>(
-        'tasks'
-    );
+    const [middleTab, setMiddleTab] = useState<
+        'tasks' | 'code' | 'tools' | 'complete'
+    >('tasks');
 
     useEffect(() => {
         // Focus input when visible
@@ -78,6 +79,16 @@ const ColumnLayout: React.FC<ColumnLayoutProps> = () => {
                         <li className="nav-item">
                             <button
                                 className={`nav-link${
+                                    middleTab === 'tools' ? ' active' : ''
+                                }`}
+                                onClick={() => setMiddleTab('tools')}
+                            >
+                                Tools
+                            </button>
+                        </li>
+                        <li className="nav-item">
+                            <button
+                                className={`nav-link${
                                     middleTab === 'complete' ? ' active' : ''
                                 }`}
                                 onClick={() => setMiddleTab('complete')}
@@ -100,6 +111,8 @@ const ColumnLayout: React.FC<ColumnLayoutProps> = () => {
                             />
                         ) : middleTab === 'code' ? (
                             <PullRequestFailures />
+                        ) : middleTab === 'tools' ? (
+                            <CustomToolsViewer />
                         ) : (
                             <ProcessTreeColumn
                                 selectedItemId={selectedItemId}

--- a/controller/src/server/routes/custom_tools.ts
+++ b/controller/src/server/routes/custom_tools.ts
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import path from 'path';
+import fs from 'fs/promises';
+import { getDB } from '../utils/db.js';
+
+const router = Router();
+
+const TOOLS_DIR = path.resolve('.custom_tools');
+
+function sanitizeToolName(name: string): string {
+    return path.basename(name).replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
+async function readToolImplementation(
+    name: string
+): Promise<string | undefined> {
+    const safeName = sanitizeToolName(name);
+    const tsPath = path.join(TOOLS_DIR, `${safeName}.ts`);
+    const jsPath = path.join(TOOLS_DIR, `${safeName}.js`);
+    try {
+        return await fs.readFile(tsPath, 'utf8');
+    } catch {
+        try {
+            return await fs.readFile(jsPath, 'utf8');
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+router.get('/', async (_req, res) => {
+    const db = await getDB();
+    try {
+        const result = await db.query(
+            `SELECT name, description, parameters_json, version, source_task_id, is_latest, created_at
+             FROM custom_tools
+             WHERE is_latest = true
+             ORDER BY name`
+        );
+        const tools = await Promise.all(
+            result.rows.map(async row => {
+                const implementation = await readToolImplementation(row.name);
+                return { ...row, implementation };
+            })
+        );
+        res.json(tools);
+    } catch (error) {
+        console.error('Error fetching custom tools:', error);
+        res.status(500).json({ error: 'Failed to fetch custom tools' });
+    } finally {
+        db.release();
+    }
+});
+
+router.get('/:name', async (req, res) => {
+    const name = sanitizeToolName(req.params.name);
+    const db = await getDB();
+    try {
+        const result = await db.query(
+            `SELECT name, description, parameters_json, version, source_task_id, is_latest, created_at
+             FROM custom_tools
+             WHERE name = $1`,
+            [name]
+        );
+        if (result.rows.length === 0) {
+            res.status(404).json({ error: 'Custom tool not found' });
+            return;
+        }
+        const implementation = await readToolImplementation(name);
+        res.json({ ...result.rows[0], implementation });
+    } catch (error) {
+        console.error(`Error fetching custom tool ${name}:`, error);
+        res.status(500).json({ error: 'Failed to fetch custom tool' });
+    } finally {
+        db.release();
+    }
+});
+
+export default router;

--- a/controller/src/server/server.ts
+++ b/controller/src/server/server.ts
@@ -13,6 +13,7 @@ import { ServerManager } from './managers/server_manager';
 import { initColorManager } from './managers/color_manager';
 import { ensureMigrations } from './utils/db_migrations';
 import { syncLocalCustomTools } from './utils/custom_tool_sync';
+import customToolsRoutes from './routes/custom_tools';
 import prEventsRoutes from './routes/pr_events';
 
 /**
@@ -48,6 +49,7 @@ async function main(): Promise<void> {
     // Add API routes
     const app = serverManager.getExpressApp();
     app.use(express.json()); // For parsing application/json
+    app.use('/api/custom-tools', customToolsRoutes);
     app.use('/api/pr-events', prEventsRoutes);
 
     // Expose the PR events manager for route handlers to use


### PR DESCRIPTION
## Summary
- expose `GET /api/custom-tools` and `GET /api/custom-tools/:name`
- wire new route into the server
- document the API in README
- view custom tools in the UI
- add extra path validation for custom tool lookups

## Testing
- `npm run lint:fix`
- `npm run build:ci`
