### PR TITLE
feat: add site design utilities

### DIFF
--- a/magi/src/utils/design/vibe_doc.ts
+++ b/magi/src/utils/design/vibe_doc.ts
@@ -1,0 +1,120 @@
+import fs from 'fs';
+import path from 'path';
+import { quick_llm_call } from '../llm_call_utils.js';
+import {
+    design_search,
+    createNumberedGrid,
+    type ImageSource,
+} from '../design_search.js';
+import { write_unique_file } from '../file_utils.js';
+import type { ResponseInput } from '../../types/shared-types.js';
+import type { DesignSearchResult } from './constants.js';
+
+const DESIGN_ASSETS_DIR = '/magi_output/shared/design_assets';
+
+export interface VibeDocResult {
+    docPath: string;
+    competitorQueries: string[];
+    imagePaths: string[];
+}
+
+export async function generate_design_vibe_doc(
+    spec: string
+): Promise<VibeDocResult> {
+    const promptMessages: ResponseInput = [
+        {
+            type: 'message',
+            role: 'system',
+            content:
+                'You are a design strategist tasked with identifying competitor websites for inspiration.',
+        },
+        {
+            type: 'message',
+            role: 'user',
+            content: `SITE SPECIFICATION:\n${spec}\n\nList 3 competitor website names or search queries that would provide good design inspiration. Respond with JSON.`,
+        },
+    ];
+
+    const raw = await quick_llm_call(promptMessages, 'reasoning', {
+        name: 'CompetitorFinder',
+        description: 'Find competitor inspiration',
+        instructions:
+            'Return a JSON object {"competitors": ["..."]} with 3 short names or queries.',
+        modelSettings: {
+            force_json: true,
+            json_schema: {
+                name: 'competitors',
+                type: 'json_schema',
+                schema: {
+                    type: 'object',
+                    properties: {
+                        competitors: {
+                            type: 'array',
+                            items: { type: 'string' },
+                            minItems: 1,
+                            maxItems: 5,
+                        },
+                    },
+                    required: ['competitors'],
+                    additionalProperties: false,
+                },
+            },
+        },
+    });
+
+    const parsed = JSON.parse(raw);
+    const queries: string[] = parsed.competitors;
+
+    const results: DesignSearchResult[] = [];
+    for (const query of queries) {
+        try {
+            const res = await design_search('web_search', query, 3);
+            const arr: DesignSearchResult[] = JSON.parse(res);
+            results.push(...arr.slice(0, 3));
+        } catch (error) {
+            console.error('design_search failed for', query, error);
+        }
+    }
+
+    const valid = results.filter(r => r.screenshotURL).slice(0, 9);
+    const grid = await createNumberedGrid(
+        valid as unknown as ImageSource[],
+        'vibe'
+    );
+
+    const analysisMessages: ResponseInput = [
+        {
+            type: 'message',
+            role: 'system',
+            content:
+                'You are a senior web art director who writes short vibe docs summarizing design direction.',
+        },
+        {
+            type: 'message',
+            role: 'user',
+            content: `SITE SPECIFICATION:\n${spec}\n\nThe following grid shows screenshots from competitor or inspirational sites. Summarize the common themes and describe how our site should be similar or different. Respond with a short Markdown document.`,
+        },
+        { type: 'message', role: 'user', content: grid },
+    ];
+
+    const doc = await quick_llm_call(analysisMessages, 'vision', {
+        name: 'VibeDocWriter',
+        description: 'Write vibe doc from competitor screenshots',
+        instructions:
+            'Analyze the screenshots and return a short markdown design brief summarizing the vibe and how to differentiate.',
+    });
+
+    const vibeDir = path.join(DESIGN_ASSETS_DIR, 'vibe_docs');
+    if (!fs.existsSync(vibeDir)) {
+        fs.mkdirSync(vibeDir, { recursive: true });
+    }
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const docPath = path.join(vibeDir, `vibe_doc_${timestamp}.md`);
+    write_unique_file(docPath, doc);
+
+    return {
+        docPath,
+        competitorQueries: queries,
+        imagePaths: valid.map(v => v.screenshotURL as string),
+    };
+}

--- a/magi/src/utils/index.ts
+++ b/magi/src/utils/index.ts
@@ -11,6 +11,8 @@ import {
 } from './image_generation.js';
 import { getDesignSearchTools, getSmartDesignTools } from './design_search.js';
 import { getBrowserTools } from './browser_utils.js';
+export * from './site_design.js';
+export * from './design/vibe_doc.js';
 
 /**
  * Get all common tools as an array of tool definitions

--- a/magi/src/utils/site_design.ts
+++ b/magi/src/utils/site_design.ts
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import {
+    DESIGN_ASSET_REFERENCE,
+    type DESIGN_ASSET_TYPES,
+} from './design/constants.js';
+import { quick_llm_call } from './llm_call_utils.js';
+import { design_image } from './image_generation.js';
+import {
+    generate_design_vibe_doc,
+    type VibeDocResult,
+} from './design/vibe_doc.js';
+import type { ResponseInput } from '../types/shared-types.js';
+
+/**
+ * Plan which design assets are needed for a project using an LLM.
+ */
+export async function select_design_assets(
+    prompt: string
+): Promise<DESIGN_ASSET_TYPES[]> {
+    const list = Object.entries(DESIGN_ASSET_REFERENCE)
+        .map(([k, v]) => `- ${k}: ${v.description}`)
+        .join('\n');
+    const choices = Object.keys(DESIGN_ASSET_REFERENCE) as DESIGN_ASSET_TYPES[];
+
+    const messages: ResponseInput = [
+        {
+            type: 'message',
+            role: 'system',
+            content:
+                'You are a design planner that selects required design assets for a website.',
+        },
+        {
+            type: 'message',
+            role: 'user',
+            content: `PROJECT DESCRIPTION:\n${prompt}\n\nAVAILABLE ASSETS:\n${list}\n\nReturn the list of asset keys needed for this project in JSON form.`,
+        },
+    ];
+
+    const raw = await quick_llm_call(messages, 'reasoning', {
+        name: 'DesignPlanner',
+        description: 'Select design assets',
+        instructions:
+            'Respond with {"assets": [..]} only using the provided keys and order of creation.',
+        modelSettings: {
+            force_json: true,
+            json_schema: {
+                name: 'asset_plan',
+                type: 'json_schema',
+                schema: {
+                    type: 'object',
+                    properties: {
+                        assets: {
+                            type: 'array',
+                            items: { type: 'string', enum: choices },
+                        },
+                    },
+                    required: ['assets'],
+                    additionalProperties: false,
+                },
+            },
+        },
+    });
+
+    const parsed = JSON.parse(raw);
+    return parsed.assets as DESIGN_ASSET_TYPES[];
+}
+
+/**
+ * Resolve dependencies for a list of assets.
+ */
+export function resolve_design_dependencies(
+    assets: DESIGN_ASSET_TYPES[]
+): DESIGN_ASSET_TYPES[] {
+    const result = new Set<DESIGN_ASSET_TYPES>();
+    function add(key: DESIGN_ASSET_TYPES) {
+        if (result.has(key)) return;
+        DESIGN_ASSET_REFERENCE[key].depends_on.forEach(dep =>
+            add(dep as DESIGN_ASSET_TYPES)
+        );
+        result.add(key);
+    }
+    assets.forEach(add);
+    return Array.from(result);
+}
+
+export interface SiteDesignResult {
+    vibe: VibeDocResult;
+    assets: Record<DESIGN_ASSET_TYPES, string>;
+}
+
+/**
+ * Generate all design assets for a site, using a vibe doc for direction and
+ * ensuring dependencies are respected.
+ */
+export async function generate_site_design(
+    prompt: string,
+    with_inspiration = true
+): Promise<SiteDesignResult> {
+    const vibe = await generate_design_vibe_doc(prompt);
+    const vibeText = fs.readFileSync(vibe.docPath, 'utf-8');
+    const designPrompt = `${prompt}\n\nVIBE:\n${vibeText}`;
+
+    const planned = await select_design_assets(designPrompt);
+    const all = resolve_design_dependencies(planned);
+    const pending = new Set<DESIGN_ASSET_TYPES>(all);
+    const generated: Record<DESIGN_ASSET_TYPES, string> = {} as Record<
+        DESIGN_ASSET_TYPES,
+        string
+    >;
+
+    while (pending.size > 0) {
+        let progressed = false;
+        for (const asset of Array.from(pending)) {
+            const deps = DESIGN_ASSET_REFERENCE[asset]
+                .depends_on as DESIGN_ASSET_TYPES[];
+            if (deps.every(d => generated[d])) {
+                const refPaths = Object.values(generated);
+                const path = await design_image(
+                    asset,
+                    designPrompt,
+                    with_inspiration,
+                    refPaths
+                );
+                generated[asset] = path;
+                pending.delete(asset);
+                progressed = true;
+            }
+        }
+        if (!progressed) throw new Error('Unresolvable dependencies');
+    }
+
+    return { vibe, assets: generated };
+}

--- a/test/tools/design-image.ts
+++ b/test/tools/design-image.ts
@@ -28,7 +28,7 @@ export default async function generateImageTest(options: ToolsOptions = {}): Pro
 
     // Test 1: Generate image with no output path (should use default location)
     if (verbose) console.log('\nTest 1: Generate image with default path');
-    const defaultPath = await design_image(type, query, with_inspiration);
+    const defaultPath = await design_image(type, query, with_inspiration, []);
     finalPaths.push(defaultPath);
     if (verbose) console.log(`Image saved to: ${defaultPath}`);
 


### PR DESCRIPTION
## Summary
- add vibe doc generation utility
- expose site design generator and vibe doc in utils index
- extend design_image with brand asset parameter
- add site design helper module
- update tests to new design_image signature

## Testing
- `npm run lint:fix`
- `npm run build:ci`
