### PR TITLE
Remove browser hooks from common agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ This will:
 - Start Postgres and controller (`docker compose up`)
 - Serve the web UI at http://localhost:3010
 
+### Project Containers
+
+If a task references a project, its Dockerfile is built and started automatically. The controller exposes running service ports via the `PROJECT_PORTS` environment variable. Agents can inspect this mapping using `getProcessProjectPorts()` to open the project at `http://localhost:<port>`.
+
 
 ### Running Tests
 
@@ -142,6 +146,7 @@ docker-compose.yml
 - **Tool Integration**: Agents can use tools like web search, code execution, and browser automation
 - **Browser Integration**: Chrome extension allows direct interaction with the web browser
 - **Smart Design Search**: Aggregates screenshots from multiple design sources and ranks them automatically
+- **Design Asset Collage**: Automatically builds a numbered collage of recent design assets
 - **Cost Tracking**: Monitors and reports on API usage costs
 - **Verifier Agents**: Optional verifier agents can call any tools; failures trigger automatic retries (default 2)
 - **Custom Tools API**: Exposes HTTP endpoints for listing and inspecting dynamic tools

--- a/common/shared-types.ts
+++ b/common/shared-types.ts
@@ -446,6 +446,7 @@ export type StreamEventType =
     | 'system_update'
     | 'quota_update'
     | 'screenshot'
+    | 'design_grid'
     | 'console'
     | 'error'
     // New types for waiting on tools
@@ -729,6 +730,12 @@ export interface ScreenshotEvent extends StreamEvent {
     cursor: { x: number; y: number, button?: 'none' | 'left' | 'middle' | 'right' };
 }
 
+export interface DesignGridEvent extends StreamEvent {
+    type: 'design_grid';
+    data: string;
+    timestamp: string;
+}
+
 /**
  * Console output streaming event
  */
@@ -824,6 +831,7 @@ export type StreamingEvent =
     | QuotaUpdateEvent
     | AudioEvent
     | ScreenshotEvent
+    | DesignGridEvent
     | ConsoleEvent
     | GitPullRequestEvent
     // Add new wait events
@@ -1158,6 +1166,7 @@ export type MessagePayloads = {
     system_status: Omit<SystemStatusEvent, 'type'>;
     quota_update: Omit<QuotaUpdateEvent, 'type'>;
     screenshot: Omit<ScreenshotEvent, 'type'>;
+    design_grid: Omit<DesignGridEvent, 'type'>;
     error: Omit<ErrorEvent, 'type'>;
     // Add new wait events
     tool_wait_start: Omit<ToolWaitStartEvent, 'type'>;

--- a/magi/src/utils/design_assets.ts
+++ b/magi/src/utils/design_assets.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { Agent } from './agent.js';
+import { ResponseInput } from '../types/shared-types.js';
+import {
+    DESIGN_ASSETS_DIR,
+    createNumberedGrid,
+    ImageSource,
+} from './design_search.js';
+import { getCommunicationManager } from './communication.js';
+
+export function listDesignAssetFiles(): string[] {
+    const results: string[] = [];
+    const walk = (dir: string) => {
+        if (!fs.existsSync(dir)) return;
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (/\.(png|jpe?g|webp)$/i.test(entry.name)) {
+                results.push(full);
+            }
+        }
+    };
+    walk(DESIGN_ASSETS_DIR);
+    return results;
+}
+
+export async function createDesignAssetsCollage(
+    limit = 9
+): Promise<string | null> {
+    const files = listDesignAssetFiles()
+        .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)
+        .slice(0, limit);
+    if (files.length === 0) return null;
+    const images: ImageSource[] = files.map(f => ({ url: f }));
+    return createNumberedGrid(images, 'all_design_assets');
+}
+
+export async function addDesignAssetsStatus(
+    agent: Agent,
+    messages: ResponseInput
+): Promise<[Agent, ResponseInput]> {
+    const collage = await createDesignAssetsCollage();
+    if (collage) {
+        messages.push({
+            type: 'message',
+            role: 'developer',
+            content: `### Design Assets\n${collage}`,
+        });
+        const comm = getCommunicationManager();
+        comm.send({
+            agent: agent.export(),
+            type: 'design_grid',
+            data: collage,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    return [agent, messages];
+}

--- a/magi/src/utils/design_search.ts
+++ b/magi/src/utils/design_search.ts
@@ -37,7 +37,7 @@ const USER_AGENT =
     'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; magi-user/1.0; +https://withmagi.com)';
 
 // Base directory for storing screenshots
-const DESIGN_ASSETS_DIR = '/magi_output/shared/design_assets';
+export const DESIGN_ASSETS_DIR = '/magi_output/shared/design_assets';
 const SLEEP = (ms = 1000) => new Promise(res => setTimeout(res, ms));
 
 /**
@@ -1853,9 +1853,12 @@ export async function createNumberedGrid(
     // Helper function for improved progressive downsampling
     const drawScaled = (
         srcImg: any, // Use 'any' to bypass TS type checking for napi-rs/canvas compatibility
-        dx: number, dy: number,
-        dw: number, dh: number,
-        srcWidth: number, srcHeight: number
+        dx: number,
+        dy: number,
+        dw: number,
+        dh: number,
+        srcWidth: number,
+        srcHeight: number
     ) => {
         // Fast path for smaller images
         if (Math.max(srcWidth, srcHeight) < 1024) {
@@ -2125,7 +2128,7 @@ export async function smart_design_raw(
     finalLimit: number = 3,
     type?: DESIGN_ASSET_TYPES,
     judge_guide?: string,
-    prefix: string = 'smart',
+    prefix: string = 'smart'
 ): Promise<DesignSearchResult[]> {
     // Track designs that have been processed
     const processedIds = new Set<string>();


### PR DESCRIPTION
## Summary
- export `DESIGN_ASSETS_DIR`
- remove browser setup hooks from core agents

## Testing
- `npm run lint:fix`
- `npm run build:ci`
