### PR TITLE
Improve project container access

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,17 @@ This will:
 - Build Docker images (controller & magi-base)
 - Start Postgres and controller (`docker compose up`)
 - Serve the web UI at http://localhost:3010
+### Project Containers
 
+When a task references a project, its `Dockerfile` is launched alongside MAGI. The controller exposes a mapping of project IDs to ports via the `PROCESS_PROJECTS` variable. Agents read this with `getProcessProjectPorts()` to open the running app at `http://localhost:<port>`.
+The port mapping itself is provided by the `PROJECT_PORTS` environment variable in the format `project_id:port`. For example:
+
+```bash
+export PROCESS_PROJECTS=webapp,docs
+export PROJECT_PORTS=webapp:4000,docs:4100
+```
+
+Agents will automatically open these URLs in their dedicated browser tabs when they start.
 
 ### Running Tests
 

--- a/magi/src/magi_agents/overseer_agent.ts
+++ b/magi/src/magi_agents/overseer_agent.ts
@@ -23,13 +23,9 @@ import {
     getMemoryTools,
     listShortTermMemories,
 } from '../utils/memory_utils.js';
-import {
-    listActiveProjects,
-    getProjectTools,
-    getExternalProjectIds,
-} from '../utils/project_utils.js';
+import { listActiveProjects, getProjectTools } from '../utils/project_utils.js';
 import { getProcessTools } from '../utils/process_tools.js';
-import { MAGI_CONTEXT, CUSTOM_TOOLS_TEXT } from './constants.js';
+import { MAGI_CONTEXT } from './constants.js';
 import { sendStreamEvent } from '../utils/communication.js';
 import { getCommonTools } from '../utils/index.js';
 import { getRunningToolTools } from '../utils/running_tools.js';

--- a/magi/src/magi_agents/web_agents/backend_agent.ts
+++ b/magi/src/magi_agents/web_agents/backend_agent.ts
@@ -12,6 +12,15 @@ import { Agent } from '../../utils/agent.js';
 import { getCommonTools } from '../../utils/index.js';
 import { createCodeAgent } from '../common_agents/code_agent.js';
 import { MAGI_CONTEXT } from '../constants.js';
+import {
+    addBrowserStatus,
+    setupAgentBrowserTools,
+} from '../../utils/browser_utils.js';
+import {
+    getProcessProjectIds,
+    getProcessProjectPorts,
+} from '../../utils/project_utils.js';
+import { ResponseInput } from '../../types/shared-types.js';
 
 /**
  * Create the backend agent for specialized API and database implementation
@@ -83,11 +92,32 @@ DATABASE MANAGEMENT:
 • Add appropriate constraints and relationships
 
 The frontend engineer will connect to your API, so ensure endpoints are well-documented and follow a consistent pattern.
+
+Your browser will automatically open the running project if available and a screenshot is included with each run for context.
 `,
         tools: [...getCommonTools()],
         workers: [createCodeAgent],
         modelClass: 'reasoning_mini',
+        onRequest: async (
+            agent: Agent,
+            messages: ResponseInput
+        ): Promise<[Agent, ResponseInput]> => {
+            return addBrowserStatus(agent, messages);
+        },
     });
+
+    const ports = getProcessProjectPorts();
+    const ids = getProcessProjectIds();
+    let startUrl: string | undefined;
+    for (const id of ids) {
+        if (ports[id]) {
+            startUrl = `http://localhost:${ports[id]}`;
+            break;
+        }
+    }
+    void setupAgentBrowserTools(agent, startUrl).catch(err =>
+        console.error('Failed to setup browser for WebBackendAgent', err)
+    );
 
     return agent;
 }

--- a/magi/src/magi_agents/web_agents/frontend_agent.ts
+++ b/magi/src/magi_agents/web_agents/frontend_agent.ts
@@ -12,6 +12,15 @@ import { Agent } from '../../utils/agent.js';
 import { getCommonTools } from '../../utils/index.js';
 import { MAGI_CONTEXT } from '../constants.js';
 import { createCodeAgent } from '../common_agents/code_agent.js';
+import {
+    addBrowserStatus,
+    setupAgentBrowserTools,
+} from '../../utils/browser_utils.js';
+import {
+    getProcessProjectIds,
+    getProcessProjectPorts,
+} from '../../utils/project_utils.js';
+import { ResponseInput } from '../../types/shared-types.js';
 
 /**
  * Create the frontend agent for specialized React/Next.js implementation
@@ -80,11 +89,32 @@ VISUAL TESTING:
 After implementing key pages, run comparison tests between your implementation and the design mockups to ensure fidelity.
 
 The backend engineer will connect your frontend to real data, so ensure your components accept appropriate props and handle loading/error states.
+
+Your browser will open to the running project if available and a screenshot of the current page will be added to your context each run.
 `,
         tools: [...getCommonTools()],
         workers: [createCodeAgent],
         modelClass: 'reasoning_mini',
+        onRequest: async (
+            agent: Agent,
+            messages: ResponseInput
+        ): Promise<[Agent, ResponseInput]> => {
+            return addBrowserStatus(agent, messages);
+        },
     });
+
+    const ports = getProcessProjectPorts();
+    const ids = getProcessProjectIds();
+    let startUrl: string | undefined;
+    for (const id of ids) {
+        if (ports[id]) {
+            startUrl = `http://localhost:${ports[id]}`;
+            break;
+        }
+    }
+    void setupAgentBrowserTools(agent, startUrl).catch(err =>
+        console.error('Failed to setup browser for WebFrontendAgent', err)
+    );
 
     return agent;
 }

--- a/magi/src/magi_agents/web_agents/operator_agent.ts
+++ b/magi/src/magi_agents/web_agents/operator_agent.ts
@@ -164,10 +164,10 @@ ${runningToolTracker.listActive()}`,
     const ports = getProcessProjectPorts();
     const ids = getProcessProjectIds();
     let startUrl: string | undefined;
-    if (ids.length > 0) {
-        const id = ids[0];
+    for (const id of ids) {
         if (ports[id]) {
             startUrl = `http://localhost:${ports[id]}`;
+            break;
         }
     }
     void setupAgentBrowserTools(agent, startUrl).catch(err =>

--- a/magi/src/magi_agents/web_agents/test_agent.ts
+++ b/magi/src/magi_agents/web_agents/test_agent.ts
@@ -15,6 +15,15 @@ import { createCodeAgent } from '../common_agents/code_agent.js';
 import { createBrowserAgent } from '../common_agents/browser_agent.js';
 import { createShellAgent } from '../common_agents/shell_agent.js';
 import { createReasoningAgent } from '../common_agents/reasoning_agent.js';
+import {
+    addBrowserStatus,
+    setupAgentBrowserTools,
+} from '../../utils/browser_utils.js';
+import {
+    getProcessProjectIds,
+    getProcessProjectPorts,
+} from '../../utils/project_utils.js';
+import { ResponseInput } from '../../types/shared-types.js';
 
 /**
  * Create the test agent for specialized validation and QA
@@ -78,6 +87,8 @@ DO NOT:
 • Rely exclusively on E2E tests when unit/integration tests would be more appropriate
 
 Your goal is to validate that the website implementation meets requirements, performs correctly, and provides a good user experience. Report issues clearly with specific actionable feedback.
+
+Your browser will open to the running project if available and a screenshot will be added to your context on each run.
 `,
         tools: [...getCommonTools()],
         workers: [
@@ -87,7 +98,26 @@ Your goal is to validate that the website implementation meets requirements, per
             createReasoningAgent,
         ],
         modelClass: 'reasoning_mini',
+        onRequest: async (
+            agent: Agent,
+            messages: ResponseInput
+        ): Promise<[Agent, ResponseInput]> => {
+            return addBrowserStatus(agent, messages);
+        },
     });
+
+    const ports = getProcessProjectPorts();
+    const ids = getProcessProjectIds();
+    let startUrl: string | undefined;
+    for (const id of ids) {
+        if (ports[id]) {
+            startUrl = `http://localhost:${ports[id]}`;
+            break;
+        }
+    }
+    void setupAgentBrowserTools(agent, startUrl).catch(err =>
+        console.error('Failed to setup browser for WebTestAgent', err)
+    );
 
     return agent;
 }

--- a/magi/src/utils/design_search.ts
+++ b/magi/src/utils/design_search.ts
@@ -1860,23 +1860,31 @@ export async function createNumberedGrid(
 
             if (imageSource.dataUrl) {
                 // Directly load from data URL if available
-                console.log(`[createNumberedGrid] Loaded image from data URL ${imageSource.dataUrl}`);
+                console.log(
+                    `[createNumberedGrid] Loaded image from data URL ${imageSource.dataUrl}`
+                );
                 img = await loadImage(imageSource.dataUrl);
-            }  else if ((imageSource as DesignSearchResult).screenshotURL) {
+            } else if ((imageSource as DesignSearchResult).screenshotURL) {
                 // Handle DesignSearchResult objects for backward compatibility
                 const design = imageSource as DesignSearchResult;
                 const src = design.thumbnailURL || design.screenshotURL;
                 if (src.startsWith('data:image')) {
-                    console.log(`[createNumberedGrid] Loaded image from data:image thumbnailURL/screenshotURL ${src}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from data:image thumbnailURL/screenshotURL ${src}`
+                    );
                     img = await loadImage(src);
                 } else if (
                     src.startsWith('/magi_output') &&
                     fs.existsSync(src)
                 ) {
-                    console.log(`[createNumberedGrid] Loaded image from /magi_output from thumbnailURL/screenshotURL ${src}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from /magi_output from thumbnailURL/screenshotURL ${src}`
+                    );
                     img = await loadImage(src);
                 } else {
-                    console.log(`[createNumberedGrid] Loaded image from source URL from thumbnailURL/screenshotURL ${src}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from source URL from thumbnailURL/screenshotURL ${src}`
+                    );
                     const res = await fetch(src);
                     const buf = Buffer.from(await res.arrayBuffer());
                     img = await loadImage(buf);
@@ -1884,16 +1892,22 @@ export async function createNumberedGrid(
             } else if (imageSource.url) {
                 // Load from URL or file path
                 if (imageSource.url.startsWith('data:image')) {
-                    console.log(`[createNumberedGrid] Loaded image from data:image URL ${imageSource.url}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from data:image URL ${imageSource.url}`
+                    );
                     img = await loadImage(imageSource.url);
                 } else if (
                     imageSource.url.startsWith('/magi_output') &&
                     fs.existsSync(imageSource.url)
                 ) {
-                    console.log(`[createNumberedGrid] Loaded image from /magi_output ${imageSource.url}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from /magi_output ${imageSource.url}`
+                    );
                     img = await loadImage(imageSource.url);
                 } else {
-                    console.log(`[createNumberedGrid] Loaded image from source URL ${imageSource.url}`);
+                    console.log(
+                        `[createNumberedGrid] Loaded image from source URL ${imageSource.url}`
+                    );
                     const res = await fetch(imageSource.url);
                     const buf = Buffer.from(await res.arrayBuffer());
                     img = await loadImage(buf);
@@ -1964,6 +1978,33 @@ export async function createNumberedGrid(
     console.log(`[${gridName}] Saved grid image to:`, filePath);
 
     return `data:image/png;base64,${out.toString('base64')}`;
+}
+
+/**
+ * Generate a grid overview of all design asset screenshots.
+ * Returns a base64 encoded PNG or null if no assets exist.
+ */
+export async function createDesignAssetsOverview(
+    limit = 20
+): Promise<string | null> {
+    const screenshotsDir = path.join(DESIGN_ASSETS_DIR, 'screenshots');
+    if (!fs.existsSync(screenshotsDir)) {
+        return null;
+    }
+
+    const files = fs
+        .readdirSync(screenshotsDir)
+        .filter(f => f.match(/\.(png|jpe?g)$/i))
+        .slice(-limit);
+
+    if (files.length === 0) return null;
+
+    const sources: ImageSource[] = files.map(f => ({
+        url: path.join(screenshotsDir, f),
+        title: f,
+    }));
+
+    return createNumberedGrid(sources, 'design_assets_overview');
 }
 
 /**


### PR DESCRIPTION
## Summary
- show how project containers are started in README
- include browser screenshots and project ports in all website agents
- show current design assets to DesignAgent
- expose helper to build design asset overview grid
- tidy unused imports
- open the first available project URL in each agent's browser
- document `PROJECT_PORTS` usage

## Testing
- `npm run lint:fix`
- `npm run build:ci`
- `npm test`
