### PR TITLE
Add XAI search via Grok provider

### DIFF
--- a/magi/src/model_providers/grok.ts
+++ b/magi/src/model_providers/grok.ts
@@ -5,6 +5,7 @@
  */
 
 import { OpenAIChat } from './openai_chat.js';
+import OpenAI from 'openai';
 
 /**
  * Grok model provider implementation
@@ -12,6 +13,26 @@ import { OpenAIChat } from './openai_chat.js';
 export class GrokProvider extends OpenAIChat {
     constructor() {
         super('xai', process.env.XAI_API_KEY, 'https://api.x.ai/v1');
+    }
+
+    prepareParameters(
+        requestParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
+    ): OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming {
+        if (Array.isArray(requestParams.tools)) {
+            const index = requestParams.tools.findIndex(
+                t =>
+                    t.type === 'function' &&
+                    (t as any).function?.name === 'grok_web_search'
+            );
+            if (index !== -1) {
+                requestParams.tools.splice(index, 1);
+                (requestParams as any).search_parameters = {
+                    mode: 'on',
+                    return_citations: true,
+                };
+            }
+        }
+        return super.prepareParameters(requestParams);
     }
 }
 

--- a/magi/src/utils/search_utils.ts
+++ b/magi/src/utils/search_utils.ts
@@ -20,6 +20,7 @@ const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const XAI_API_KEY = process.env.XAI_API_KEY;
 
 /**
  * Search using the Brave Search API
@@ -178,6 +179,20 @@ export async function web_search(
                 },
                 inject_agent_id
             );
+        case 'xai':
+            if (!XAI_API_KEY) return 'Error: X.AI API key not configured.';
+            return await quick_llm_call(
+                query,
+                null,
+                {
+                    model: 'grok-3-latest',
+                    name: 'GrokSearch',
+                    description: 'Search the web',
+                    instructions: 'Please search the web for this query.',
+                    tools: [signalToolFunction('grok_web_search')],
+                },
+                inject_agent_id
+            );
     }
     return `Error: Invalid or unsupported search engine ${engine}`;
 }
@@ -212,6 +227,10 @@ export function getSearchTools(): ToolFunction[] {
         engineDescriptions.push(
             '- google: freshest breaking-news facts via Gemini grounding'
         );
+    }
+    if (XAI_API_KEY) {
+        availableEngines.push('xai');
+        engineDescriptions.push('- xai: real-time web search via Grok');
     }
     if (OPENROUTER_API_KEY) {
         availableEngines.push('sonar');


### PR DESCRIPTION
## Summary
- support X.AI search engine through Grok model provider
- expose `grok_web_search` tool in `web_search`

## Testing
- `npm run lint:fix`
- `npm run build:ci`
