### PR TITLE
Fix task failure reporting and process shutdown

### DIFF
--- a/controller/src/server/managers/communication_manager.ts
+++ b/controller/src/server/managers/communication_manager.ts
@@ -698,6 +698,24 @@ export class CommunicationManager {
                     })
                 );
             }
+        } else if (event.type === 'process_failed') {
+            // Update process state and notify overseer
+            this.processManager.updateProcessWithError(
+                processId,
+                (event as any).error || 'Unknown error'
+            );
+
+            this.sendMessage(
+                this.processManager.coreProcessId,
+                JSON.stringify({
+                    type: 'process_event',
+                    processId,
+                    event,
+                })
+            );
+
+            // Ensure the container terminates after a failure
+            await this.processManager.stopProcess(processId);
         } else if (
             event.type === 'process_running' ||
             event.type === 'process_updated' ||

--- a/magi/src/magi.ts
+++ b/magi/src/magi.ts
@@ -392,6 +392,10 @@ async function main(): Promise<void> {
             status: 'process_done',
         });
 
+        if (args.tool && args.tool !== 'none') {
+            return endProcess(0, 'Task run completed.');
+        }
+
         if (args.test) {
             // For tests we terminate after the first run
             return endProcess(0, 'Test run completed.');


### PR DESCRIPTION
## Summary
- forward `process_failed` events from containers to the core controller
- mark failed tasks on the controller and stop the container
- ensure task containers terminate after MECH execution

## Testing
- `npm run lint:fix`
- `npm run build:ci`
