### PR TITLE
Handle failed task events

### DIFF
--- a/controller/src/server/managers/communication_manager.ts
+++ b/controller/src/server/managers/communication_manager.ts
@@ -698,6 +698,20 @@ export class CommunicationManager {
                     })
                 );
             }
+        } else if (event.type === 'process_failed') {
+            this.processManager.updateProcessWithError(
+                processId,
+                event.error ?? ''
+            );
+            await this.processManager.runCompletionHandlers(processId);
+            this.sendMessage(
+                this.processManager.coreProcessId,
+                JSON.stringify({
+                    type: 'process_event',
+                    processId,
+                    event,
+                })
+            );
         } else if (
             event.type === 'process_running' ||
             event.type === 'process_updated' ||


### PR DESCRIPTION
## Summary
- forward `process_failed` messages to the controller and update process status
- stop MAGI containers when tool runs fail and report failure via `process_failed`

## Testing
- `npm run lint:fix`
- `npm run build:ci`
