### PR TITLE
Implement radial layout and trim message display

### DIFF
--- a/controller/src/client/js/components/canvas_ui/AgentBox.tsx
+++ b/controller/src/client/js/components/canvas_ui/AgentBox.tsx
@@ -56,6 +56,9 @@ const AgentBox: React.FC<AgentBoxWithParentProcess> = ({
     const clickTimeout = useRef<number | null>(null);
     const clickCount = useRef<number>(0);
     const [mounted, setMounted] = useState(false);
+    const heavyAgent = ['browser', 'code', 'design'].some(t =>
+        agentName.toLowerCase().includes(t)
+    );
 
     // Effect to handle mount animation
     useEffect(() => {
@@ -153,6 +156,7 @@ const AgentBox: React.FC<AgentBoxWithParentProcess> = ({
                         messages={messages}
                         isTyping={isTyping}
                         colors={colors}
+                        latestOnly={!heavyAgent}
                     />
                 </AutoScrollContainer>
             </div>

--- a/controller/src/client/js/components/canvas_ui/ProcessBox.tsx
+++ b/controller/src/client/js/components/canvas_ui/ProcessBox.tsx
@@ -52,6 +52,11 @@ const ProcessBox: React.FC<ProcessBoxProps> = ({
     const messages = process ? process.agent.messages : [];
     const agentName = process?.agent.name;
     const isTyping = process?.agent.isTyping || false;
+    const heavyAgent = agentName
+        ? ['browser', 'code', 'design'].some(t =>
+              agentName.toLowerCase().includes(t)
+          )
+        : false;
 
     // Effect to handle mount animation
     useEffect(() => {
@@ -129,6 +134,7 @@ const ProcessBox: React.FC<ProcessBoxProps> = ({
                         messages={messages}
                         isTyping={isTyping}
                         colors={colors}
+                        latestOnly={!isCoreProcess && !heavyAgent}
                     />
                 </AutoScrollContainer>
             </div>

--- a/controller/src/client/js/components/message/MessageList.tsx
+++ b/controller/src/client/js/components/message/MessageList.tsx
@@ -25,6 +25,8 @@ interface MessageListProps {
         bgColor: string;
         textColor: string;
     };
+    /** Only display the most recent message */
+    latestOnly?: boolean;
 }
 
 const MessageList: React.FC<MessageListProps> = ({
@@ -32,6 +34,7 @@ const MessageList: React.FC<MessageListProps> = ({
     messages,
     isTyping,
     colors,
+    latestOnly,
 }) => {
     colors = colors || {
         rgb: '0 0 0',
@@ -55,11 +58,14 @@ const MessageList: React.FC<MessageListProps> = ({
 
     // Process messages to handle deltas and sorting
     const filteredMessages = processMessages(messages);
+    const messagesToRender = latestOnly
+        ? filteredMessages.slice(-1)
+        : filteredMessages;
 
     return (
         <div className="message-container">
-            {filteredMessages.map((message, index) =>
-                renderMessage(message, colors.rgb, filteredMessages, index)
+            {messagesToRender.map((message, index) =>
+                renderMessage(message, colors.rgb, messagesToRender, index)
             )}
             {renderTypingIndicator(isTyping, colors.textColor)}
         </div>

--- a/controller/src/client/js/components/utils/GridUtils.tsx
+++ b/controller/src/client/js/components/utils/GridUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Grid Utilities for Process Grid Layout - Revised Deterministic Layout (Fixed Scope Error)
+ * Grid utilities for positioning boxes in a radial layout around the core process.
  */
 import { ProcessData } from '../../context/SocketContext';
 import { BoxPosition } from '../../../../types';
@@ -21,10 +21,10 @@ const MIN_ZOOM = 0.2; // Minimum allowed zoom level
 const MAX_ZOOM = 2; // Maximum allowed zoom level
 
 // --- Interfaces ---
-interface GridPosition {
-    row: number;
-    col: number;
-}
+// interface GridPosition {
+//     row: number;
+//     col: number;
+// }
 
 // --- Helper Functions ---
 
@@ -72,46 +72,11 @@ export const getOrigin = (containerSize: {
     };
 };
 
-/**
- * Calculates screen coordinates for the top-left of a grid cell.
- * Rows < -1 (worker rows) are treated as half the height of standard rows.
- */
-const gridToScreenCoords = (
-    row: number,
-    col: number,
-    originX: number,
-    originY: number,
-    squareWidth: number,
-    squareHeight: number
-): { x: number; y: number } => {
-    const fullStep = squareHeight + GRID_PADDING;
-    let y: number;
-
-    if (row >= -1) {
-        // Standard calculation for row 0, -1
-        y = originY + row * fullStep;
-    } else {
-        // Special calculation for rows < -1 (worker rows stacking upwards)
-        // Start from the position of row -1 and subtract half steps for subsequent rows
-        const yForRowMinus1 = originY - fullStep;
-        const numHalfStepsAboveRowMinus1 = -row - 1; // e.g., row -2 is 1 half step, row -3 is 2 half steps
-        y = yForRowMinus1 - numHalfStepsAboveRowMinus1 * (fullStep / 2);
-        // Alternative formula derived: y = originY - fullStep * (1 + (-row - 1) / 2)
-    }
-
-    return {
-        x: originX + col * (squareWidth + GRID_PADDING),
-        y: y,
-    };
-};
-
 // --- Main Exported Functions ---
 
 /**
- * Calculates grid positions using a revised deterministic layout:
- * - Core (Scale 2) at grid origin (0, 0).
- * - Scale 1 processes and Core's workers spread horizontally in row -1, starting above core's col 0.
- * - Workers of Scale 1 processes placed 2 per row, stacking vertically above their parent (row -2, -3, ...).
+ * Calculate positions for all boxes using a radial star layout.
+ * The core process is centred and every other task or worker orbits around it.
  */
 export const calculateBoxPositions = (
     coreProcessId: string,
@@ -120,133 +85,77 @@ export const calculateBoxPositions = (
 ): Map<string, BoxPosition> => {
     if (processes.size === 0) return new Map<string, BoxPosition>();
 
-    // --- Initialization ---
     const positionsMap = new Map<string, BoxPosition>();
-    // Stores calculated grid positions for parent lookup
-    const processGridPositions = new Map<string, GridPosition>();
-
     const { squareWidth, squareHeight, originX, originY } =
         getOrigin(containerSize);
 
-    // --- 1. Place Core Process ---
+    const centerX = originX + squareWidth / 2;
+    const centerY = originY + squareHeight / 2;
+
     const coreProcess = processes.get(coreProcessId);
     if (!coreProcess) {
         console.error(`Core process with ID ${coreProcessId} not found.`);
-        return new Map<string, BoxPosition>();
+        return positionsMap;
     }
 
-    const coreGridPos: GridPosition = { row: 0, col: 0 };
-    const { x: coreX, y: coreY } = gridToScreenCoords(
-        coreGridPos.row,
-        coreGridPos.col,
-        originX,
-        originY,
-        squareWidth,
-        squareHeight
-    );
-
-    // Store BASE dimensions; scale will handle visual size
     positionsMap.set(coreProcessId, {
-        x: coreX,
-        y: coreY,
-        width: squareWidth + GRID_PADDING / 2, // Store base width (1x1 cell)
-        height: squareHeight + GRID_PADDING / 2, // Store base height (1x1 cell)
-        scale: CORE_SCALE, // Scale indicates it visually covers 2x2
+        x: centerX - squareWidth / 2,
+        y: centerY - squareHeight / 2,
+        width: squareWidth,
+        height: squareHeight,
+        scale: CORE_SCALE,
     });
-    processGridPositions.set(coreProcessId, coreGridPos);
 
-    // --- 2. Prepare and Place Row -1 Items ---
-    const rowMinus1ItemIds: string[] = [];
-    processes.forEach((_process, id) => {
-        if (id !== coreProcessId) rowMinus1ItemIds.push(id); // Add non-core processes
+    const taskIds: string[] = [];
+    processes.forEach((_p, id) => {
+        if (id !== coreProcessId) taskIds.push(id);
     });
-    const coreWorkers = coreProcess.agent?.workers
-        ? Array.from(coreProcess.agent.workers.keys())
-        : [];
-    rowMinus1ItemIds.push(...coreWorkers); // Add core's workers
+    if (coreProcess.agent?.workers) {
+        taskIds.push(...Array.from(coreProcess.agent.workers.keys()));
+    }
 
-    let leftCol = 0; // Start placing leftwards from col -1
-    let rightCol = 1; // Start placing rightwards from col 0 (directly above core's left)
-    rowMinus1ItemIds.forEach((itemId, index) => {
-        const itemScale = DEFAULT_SCALE;
-        const itemWidth = squareWidth; // Base width/height for position calculation
-        const itemHeight = squareHeight;
-
-        // Assign column alternating right/left, starting from col 0
-        const itemCol = index % 2 === 0 ? leftCol-- : rightCol++;
-        const itemGridPos: GridPosition = { row: -1, col: itemCol };
-
-        const { x, y } = gridToScreenCoords(
-            itemGridPos.row,
-            itemGridPos.col,
-            originX,
-            originY,
-            squareWidth,
-            squareHeight
-        );
-        positionsMap.set(itemId, {
+    const taskRadius = Math.max(squareWidth, squareHeight) * 3;
+    const taskStep = taskIds.length > 0 ? (2 * Math.PI) / taskIds.length : 0;
+    taskIds.forEach((taskId, index) => {
+        const angle = index * taskStep;
+        const x = centerX + taskRadius * Math.cos(angle) - squareWidth / 2;
+        const y = centerY + taskRadius * Math.sin(angle) - squareHeight / 2;
+        positionsMap.set(taskId, {
             x,
             y,
-            width: itemWidth, // Store base width
-            height: itemHeight, // Store base height
-            scale: itemScale, // Store correct scale for rendering/bounding box
+            width: squareWidth,
+            height: squareHeight,
+            scale: DEFAULT_SCALE,
         });
-        processGridPositions.set(itemId, itemGridPos);
     });
 
-    // --- 3. Place Workers of Scale 1 Processes ---
+    const workerRadius = squareWidth * 1.5;
     processes.forEach((process, id) => {
-        if (id === coreProcessId) return; // Skip core process
+        const parentPos = positionsMap.get(id);
+        if (!parentPos || !process.agent?.workers) return;
 
-        if (process.agent?.workers && process.agent.workers.size > 0) {
-            const parentGridPos = processGridPositions.get(id);
-            if (!parentGridPos) {
-                console.error(
-                    `Could not find grid position for parent process ${id} when placing workers.`
-                );
-                return;
-            }
-
-            const workers = Array.from(process.agent.workers.keys());
-            workers.forEach((workerId, workerIndex) => {
-                // Determine the grid cell row (2 workers per row, stacking up)
-                const workerGridRow =
-                    parentGridPos.row - 1 - Math.floor(workerIndex / 2);
-                const workerGridCol = parentGridPos.col; // Align with parent column
-
-                // Calculate base screen coords for the cell the worker pair resides in
-                const { x: cellX, y: cellY } = gridToScreenCoords(
-                    workerGridRow,
-                    workerGridCol,
-                    originX,
-                    originY,
-                    squareWidth,
-                    squareHeight
-                );
-
-                // Determine position within the cell (left or right)
-                const isLeftWorker =
-                    workerGridCol < 1
-                        ? workerIndex % 2 !== 0
-                        : workerIndex % 2 === 0;
-                // Position workers side-by-side within the cell width.
-                // Offset for the right worker is roughly half the cell width.
-                // A small padding adjustment might be needed depending on visuals.
-                const xOffset = isLeftWorker
-                    ? 0
-                    : squareWidth / 2 + GRID_PADDING / 4; // Adjusted offset for right worker
-                const workerX = cellX + xOffset;
-                const workerY = cellY; // Workers align vertically within their row
-
-                positionsMap.set(workerId, {
-                    x: workerX,
-                    y: workerY,
-                    width: squareWidth - GRID_PADDING / 2, // Store base width
-                    height: squareHeight - GRID_PADDING / 2, // Store base height
-                    scale: WORKER_SCALE,
-                });
+        const workers = Array.from(process.agent.workers.keys());
+        const step = workers.length > 0 ? (2 * Math.PI) / workers.length : 0;
+        workers.forEach((workerId, wIndex) => {
+            const angle = wIndex * step;
+            const wx =
+                parentPos.x +
+                squareWidth / 2 +
+                workerRadius * Math.cos(angle) -
+                squareWidth / 2;
+            const wy =
+                parentPos.y +
+                squareHeight / 2 +
+                workerRadius * Math.sin(angle) -
+                squareHeight / 2;
+            positionsMap.set(workerId, {
+                x: wx,
+                y: wy,
+                width: squareWidth,
+                height: squareHeight,
+                scale: WORKER_SCALE,
             });
-        }
+        });
     });
 
     return positionsMap;

--- a/controller/src/client/js/context/SocketContext.tsx
+++ b/controller/src/client/js/context/SocketContext.tsx
@@ -1095,16 +1095,14 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
                         }
 
                         // Remove the process after animation delay
-                        /* Disabled for debugging for now... @todo only disable when entire system terminated (e.g. via SIGINT)
-						setTimeout(() => {
-							setProcesses(prevProcesses => {
-								const updatedProcesses = new Map(prevProcesses);
-								updatedProcesses.delete(event.id);
+                        setTimeout(() => {
+                            setProcesses(prevProcesses => {
+                                const updatedProcesses = new Map(prevProcesses);
+                                updatedProcesses.delete(event.id);
 
-								return updatedProcesses;
-							});
-						}, 1200); // Same delay as in ProcessUI
-						*/
+                                return updatedProcesses;
+                            });
+                        }, 1200); // Same delay as in ProcessUI
                     }
                 }
 


### PR DESCRIPTION
## Summary
- cluster process and agent boxes in a radial star layout
- hide older messages for lightweight agents to reduce render load
- remove finished processes after animation delay

## Testing
- `npm run lint:fix`
- `npm run build:ci`
