### PR TITLE
Improve canvas layout and message display

### DIFF
--- a/controller/src/client/js/components/canvas_ui/AgentBox.tsx
+++ b/controller/src/client/js/components/canvas_ui/AgentBox.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useRef, useEffect, useState } from 'react';
+import { processMessages } from '../utils/ProcessBoxUtils';
 import { ClientMessage } from '../../context/SocketContext';
 import MessageList from '../message/MessageList';
 import ProcessHeader from '../ui/ProcessHeader';
@@ -56,6 +57,12 @@ const AgentBox: React.FC<AgentBoxWithParentProcess> = ({
     const clickTimeout = useRef<number | null>(null);
     const clickCount = useRef<number>(0);
     const [mounted, setMounted] = useState(false);
+    const heavyAgent = ['browser', 'code', 'design'].some(t =>
+        agentName.toLowerCase().includes(t)
+    );
+    const displayMessages = heavyAgent
+        ? messages
+        : processMessages(messages).slice(-1);
 
     // Effect to handle mount animation
     useEffect(() => {
@@ -150,7 +157,7 @@ const AgentBox: React.FC<AgentBoxWithParentProcess> = ({
 
                 <AutoScrollContainer className="process-logs card-body">
                     <MessageList
-                        messages={messages}
+                        messages={displayMessages}
                         isTyping={isTyping}
                         colors={colors}
                     />

--- a/controller/src/client/js/components/canvas_ui/ProcessBox.tsx
+++ b/controller/src/client/js/components/canvas_ui/ProcessBox.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { useRef, useEffect, useState } from 'react';
+import { processMessages } from '../utils/ProcessBoxUtils';
 import { ProcessStatus } from '../../../../types';
 import { useSocket } from '../../context/SocketContext';
 import MessageList from '../message/MessageList';
@@ -52,6 +53,14 @@ const ProcessBox: React.FC<ProcessBoxProps> = ({
     const messages = process ? process.agent.messages : [];
     const agentName = process?.agent.name;
     const isTyping = process?.agent.isTyping || false;
+    const heavyAgent = agentName
+        ? ['browser', 'code', 'design'].some(t =>
+              agentName.toLowerCase().includes(t)
+          )
+        : false;
+    const displayMessages = heavyAgent
+        ? messages
+        : processMessages(messages).slice(-1);
 
     // Effect to handle mount animation
     useEffect(() => {
@@ -126,7 +135,7 @@ const ProcessBox: React.FC<ProcessBoxProps> = ({
                 <AutoScrollContainer className="process-logs card-body">
                     <MessageList
                         agent={process?.agent}
-                        messages={messages}
+                        messages={displayMessages}
                         isTyping={isTyping}
                         colors={colors}
                     />

--- a/controller/src/client/js/components/utils/GridUtils.tsx
+++ b/controller/src/client/js/components/utils/GridUtils.tsx
@@ -1,5 +1,5 @@
 /**
- * Grid Utilities for Process Grid Layout - Revised Deterministic Layout (Fixed Scope Error)
+ * Grid utilities for the radial canvas layout
  */
 import { ProcessData } from '../../context/SocketContext';
 import { BoxPosition } from '../../../../types';
@@ -17,14 +17,13 @@ const CORE_SCALE = 2;
 const DEFAULT_SCALE = 1;
 const WORKER_SCALE = 0.5;
 
+const HEAVY_AGENT_NAMES = ['browser', 'code', 'design'];
+
+const isHeavyAgent = (name?: string): boolean =>
+    !!name && HEAVY_AGENT_NAMES.some(t => name.toLowerCase().includes(t));
+
 const MIN_ZOOM = 0.2; // Minimum allowed zoom level
 const MAX_ZOOM = 2; // Maximum allowed zoom level
-
-// --- Interfaces ---
-interface GridPosition {
-    row: number;
-    col: number;
-}
 
 // --- Helper Functions ---
 
@@ -72,46 +71,22 @@ export const getOrigin = (containerSize: {
     };
 };
 
-/**
- * Calculates screen coordinates for the top-left of a grid cell.
- * Rows < -1 (worker rows) are treated as half the height of standard rows.
- */
-const gridToScreenCoords = (
-    row: number,
-    col: number,
-    originX: number,
-    originY: number,
-    squareWidth: number,
-    squareHeight: number
-): { x: number; y: number } => {
-    const fullStep = squareHeight + GRID_PADDING;
-    let y: number;
-
-    if (row >= -1) {
-        // Standard calculation for row 0, -1
-        y = originY + row * fullStep;
-    } else {
-        // Special calculation for rows < -1 (worker rows stacking upwards)
-        // Start from the position of row -1 and subtract half steps for subsequent rows
-        const yForRowMinus1 = originY - fullStep;
-        const numHalfStepsAboveRowMinus1 = -row - 1; // e.g., row -2 is 1 half step, row -3 is 2 half steps
-        y = yForRowMinus1 - numHalfStepsAboveRowMinus1 * (fullStep / 2);
-        // Alternative formula derived: y = originY - fullStep * (1 + (-row - 1) / 2)
-    }
-
-    return {
-        x: originX + col * (squareWidth + GRID_PADDING),
-        y: y,
-    };
-};
-
 // --- Main Exported Functions ---
 
+const hashString = (str: string): number => {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash |= 0; // Convert to 32bit integer
+    }
+    return Math.abs(hash);
+};
+
 /**
- * Calculates grid positions using a revised deterministic layout:
- * - Core (Scale 2) at grid origin (0, 0).
- * - Scale 1 processes and Core's workers spread horizontally in row -1, starting above core's col 0.
- * - Workers of Scale 1 processes placed 2 per row, stacking vertically above their parent (row -2, -3, ...).
+ * Calculate positions for a radial star-cluster layout.
+ * The core process is centered and all tasks orbit closely around it.
+ * Workers of each task orbit their parent. Heavy workers (browser, code,
+ * design) are rendered at full scale while lightweight workers are smaller.
  */
 export const calculateBoxPositions = (
     coreProcessId: string,
@@ -120,133 +95,91 @@ export const calculateBoxPositions = (
 ): Map<string, BoxPosition> => {
     if (processes.size === 0) return new Map<string, BoxPosition>();
 
-    // --- Initialization ---
     const positionsMap = new Map<string, BoxPosition>();
-    // Stores calculated grid positions for parent lookup
-    const processGridPositions = new Map<string, GridPosition>();
-
     const { squareWidth, squareHeight, originX, originY } =
         getOrigin(containerSize);
 
-    // --- 1. Place Core Process ---
+    const centerX = originX + squareWidth / 2;
+    const centerY = originY + squareHeight / 2;
+
     const coreProcess = processes.get(coreProcessId);
     if (!coreProcess) {
         console.error(`Core process with ID ${coreProcessId} not found.`);
-        return new Map<string, BoxPosition>();
+        return positionsMap;
     }
 
-    const coreGridPos: GridPosition = { row: 0, col: 0 };
-    const { x: coreX, y: coreY } = gridToScreenCoords(
-        coreGridPos.row,
-        coreGridPos.col,
-        originX,
-        originY,
-        squareWidth,
-        squareHeight
-    );
-
-    // Store BASE dimensions; scale will handle visual size
     positionsMap.set(coreProcessId, {
-        x: coreX,
-        y: coreY,
-        width: squareWidth + GRID_PADDING / 2, // Store base width (1x1 cell)
-        height: squareHeight + GRID_PADDING / 2, // Store base height (1x1 cell)
-        scale: CORE_SCALE, // Scale indicates it visually covers 2x2
+        x: centerX - squareWidth / 2,
+        y: centerY - squareHeight / 2,
+        width: squareWidth,
+        height: squareHeight,
+        scale: CORE_SCALE,
     });
-    processGridPositions.set(coreProcessId, coreGridPos);
 
-    // --- 2. Prepare and Place Row -1 Items ---
-    const rowMinus1ItemIds: string[] = [];
-    processes.forEach((_process, id) => {
-        if (id !== coreProcessId) rowMinus1ItemIds.push(id); // Add non-core processes
+    const taskIds: string[] = [];
+    processes.forEach((_p, id) => {
+        if (id !== coreProcessId) taskIds.push(id);
     });
     const coreWorkers = coreProcess.agent?.workers
         ? Array.from(coreProcess.agent.workers.keys())
         : [];
-    rowMinus1ItemIds.push(...coreWorkers); // Add core's workers
+    taskIds.push(...coreWorkers);
 
-    let leftCol = 0; // Start placing leftwards from col -1
-    let rightCol = 1; // Start placing rightwards from col 0 (directly above core's left)
-    rowMinus1ItemIds.forEach((itemId, index) => {
-        const itemScale = DEFAULT_SCALE;
-        const itemWidth = squareWidth; // Base width/height for position calculation
-        const itemHeight = squareHeight;
+    const sortedTasks = [...taskIds].sort(
+        (a, b) => hashString(a) - hashString(b)
+    );
 
-        // Assign column alternating right/left, starting from col 0
-        const itemCol = index % 2 === 0 ? leftCol-- : rightCol++;
-        const itemGridPos: GridPosition = { row: -1, col: itemCol };
+    const taskRadius = squareWidth + GRID_PADDING * 1.5;
 
-        const { x, y } = gridToScreenCoords(
-            itemGridPos.row,
-            itemGridPos.col,
-            originX,
-            originY,
-            squareWidth,
-            squareHeight
-        );
-        positionsMap.set(itemId, {
+    sortedTasks.forEach((taskId, index) => {
+        const angle = (index / sortedTasks.length) * 2 * Math.PI;
+        const x = centerX + taskRadius * Math.cos(angle) - squareWidth / 2;
+        const y = centerY + taskRadius * Math.sin(angle) - squareHeight / 2;
+        positionsMap.set(taskId, {
             x,
             y,
-            width: itemWidth, // Store base width
-            height: itemHeight, // Store base height
-            scale: itemScale, // Store correct scale for rendering/bounding box
+            width: squareWidth,
+            height: squareHeight,
+            scale: DEFAULT_SCALE,
         });
-        processGridPositions.set(itemId, itemGridPos);
     });
 
-    // --- 3. Place Workers of Scale 1 Processes ---
     processes.forEach((process, id) => {
-        if (id === coreProcessId) return; // Skip core process
-
-        if (process.agent?.workers && process.agent.workers.size > 0) {
-            const parentGridPos = processGridPositions.get(id);
-            if (!parentGridPos) {
-                console.error(
-                    `Could not find grid position for parent process ${id} when placing workers.`
-                );
-                return;
-            }
-
-            const workers = Array.from(process.agent.workers.keys());
-            workers.forEach((workerId, workerIndex) => {
-                // Determine the grid cell row (2 workers per row, stacking up)
-                const workerGridRow =
-                    parentGridPos.row - 1 - Math.floor(workerIndex / 2);
-                const workerGridCol = parentGridPos.col; // Align with parent column
-
-                // Calculate base screen coords for the cell the worker pair resides in
-                const { x: cellX, y: cellY } = gridToScreenCoords(
-                    workerGridRow,
-                    workerGridCol,
-                    originX,
-                    originY,
-                    squareWidth,
-                    squareHeight
-                );
-
-                // Determine position within the cell (left or right)
-                const isLeftWorker =
-                    workerGridCol < 1
-                        ? workerIndex % 2 !== 0
-                        : workerIndex % 2 === 0;
-                // Position workers side-by-side within the cell width.
-                // Offset for the right worker is roughly half the cell width.
-                // A small padding adjustment might be needed depending on visuals.
-                const xOffset = isLeftWorker
-                    ? 0
-                    : squareWidth / 2 + GRID_PADDING / 4; // Adjusted offset for right worker
-                const workerX = cellX + xOffset;
-                const workerY = cellY; // Workers align vertically within their row
-
-                positionsMap.set(workerId, {
-                    x: workerX,
-                    y: workerY,
-                    width: squareWidth - GRID_PADDING / 2, // Store base width
-                    height: squareHeight - GRID_PADDING / 2, // Store base height
-                    scale: WORKER_SCALE,
-                });
+        const parentPos = positionsMap.get(id);
+        if (!parentPos || !process.agent?.workers) return;
+        const workerEntries = Array.from(process.agent.workers.entries());
+        if (workerEntries.length === 0) return;
+        const sortedWorkers = workerEntries.sort(
+            ([a], [b]) => hashString(a) - hashString(b)
+        );
+        const workerRadius = squareWidth + GRID_PADDING;
+        sortedWorkers.forEach(([workerId, workerData], wIndex) => {
+            if (positionsMap.has(workerId)) return;
+            const angle = (wIndex / sortedWorkers.length) * 2 * Math.PI;
+            const x =
+                parentPos.x +
+                parentPos.width / 2 +
+                workerRadius * Math.cos(angle) -
+                squareWidth / 2;
+            const y =
+                parentPos.y +
+                parentPos.height / 2 +
+                workerRadius * Math.sin(angle) -
+                squareHeight / 2;
+            positionsMap.set(workerId, {
+                x,
+                y,
+                width: isHeavyAgent(workerData.name)
+                    ? squareWidth
+                    : squareWidth - GRID_PADDING / 2,
+                height: isHeavyAgent(workerData.name)
+                    ? squareHeight
+                    : squareHeight - GRID_PADDING / 2,
+                scale: isHeavyAgent(workerData.name)
+                    ? DEFAULT_SCALE
+                    : WORKER_SCALE,
             });
-        }
+        });
     });
 
     return positionsMap;

--- a/controller/src/client/js/context/SocketContext.tsx
+++ b/controller/src/client/js/context/SocketContext.tsx
@@ -1095,16 +1095,14 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
                         }
 
                         // Remove the process after animation delay
-                        /* Disabled for debugging for now... @todo only disable when entire system terminated (e.g. via SIGINT)
-						setTimeout(() => {
-							setProcesses(prevProcesses => {
-								const updatedProcesses = new Map(prevProcesses);
-								updatedProcesses.delete(event.id);
+                        setTimeout(() => {
+                            setProcesses(prevProcesses => {
+                                const updatedProcesses = new Map(prevProcesses);
+                                updatedProcesses.delete(event.id);
 
-								return updatedProcesses;
-							});
-						}, 1200); // Same delay as in ProcessUI
-						*/
+                                return updatedProcesses;
+                            });
+                        }, 1200); // Same delay as in ProcessUI
                     }
                 }
 


### PR DESCRIPTION
## Summary
- reposition processes closer to the core using a radial layout
- randomly distribute tasks and workers and keep heavy worker boxes the same size
- heavy agents still show all messages, light agents show only latest
- remove terminated processes after animation delay

## Testing
- `npm run lint:fix`
- `npm run build:ci`
